### PR TITLE
Link with math library on Linux.

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,9 @@
+UNAME := $(shell uname)
+
 # just for R CMD check
 #PKG_CFLAGS=-flto -fsanitize=undefined 
 #PKG_LIBS=-lubsan
+
+ifeq ($(UNAME), Linux)
+PKG_LIBS += -lm
+endif


### PR DESCRIPTION
Since math functions are used, this is necessary on Linux. Otherwise, strange failures occur due to incorrect math implementations being used: https://bugzilla.redhat.com/show_bug.cgi?id=1763127