### PR TITLE
Fix #19

### DIFF
--- a/src/integer64.c
+++ b/src/integer64.c
@@ -100,7 +100,7 @@ SEXP as_integer64_double(SEXP x_, SEXP ret_){
     if (ISNAN(x[i])) 
 	  ret[i] = NA_INTEGER64;
 	else{
-	  if (x[i]<imin || x[i]>imax){
+	  if (x[i]<imin || x[i]>=imax){
 	    ret[i] = NA_INTEGER64;
 		naflag = TRUE;
 	  }else


### PR DESCRIPTION
`bit64::as.integer64(2^63)` produces different results on different machines (see #19). `2^63` is stored as double in R. When converting double `2^63` to `long long`, M1 Mac results in `9223372036854775807`.


```r
print_bit <- Rcpp::cppFunction(r"(
SEXP print_bit(SEXP obj){
  
  long long tmp1 = *REAL0(obj);
  printf("%lld ", tmp1);
  printf("%f ", (double(tmp1)));

  return(R_NilValue);
}
)")
invisible(print_bit(2^63))

# M1 Mac
> 9223372036854775807 9223372036854775808.000000 

# x86_64 Ubuntu 
> -9223372036854775808 -9223372036854775808.000000
```

Therefore, I propose this change from `if (x[i]<imin || x[i]>imax)` to `if (x[i]<imin || x[i]>=imax)`.

(This change will trigger `naflag`)